### PR TITLE
Add support for running O1 before instrumentation

### DIFF
--- a/llvm/test/tools/input-gen/o1-optimization.ll
+++ b/llvm/test/tools/input-gen/o1-optimization.ll
@@ -1,0 +1,10 @@
+; RUN: mkdir -p %t
+; RUN: input-gen --verify --output-dir %t --compile-input-gen-executables --input-gen-runtime %S/../../../../input-gen-runtimes/rt-input-gen.cpp --input-run-runtime %S/../../../../input-gen-runtimes/rt-run.cpp --optimize-before-instrumenting %s
+; RUN: %S/run_all.sh %t
+
+define dso_local i64 @i64(ptr noundef %LL) local_unnamed_addr #0 {
+entry:
+  %a = load i64, ptr %LL
+  store i64 %a, ptr %LL
+  ret i64 %a
+}


### PR DESCRIPTION
This patch adds support for running optimizations (specifically the O1 pipeline) before instrumentation. This will run passes like SROA which might end up making instrumentation faster and is something that we want to experiment with regardless.