### PR TITLE
Add initial support for PGO instrumentation/use in inputgen

### DIFF
--- a/llvm/test/tools/input-gen/pgo.ll
+++ b/llvm/test/tools/input-gen/pgo.ll
@@ -1,0 +1,14 @@
+; RUN: mkdir -p %t
+; RUN: input-gen --verify --output-dir %t --compile-input-gen-executables --input-gen-runtime %S/../../../../input-gen-runtimes/rt-input-gen.cpp --input-run-runtime %S/../../../../input-gen-runtimes/rt-run.cpp --pgo-instr-generate %s
+; RUN: %t/input-gen.module.generate.a.out %t 0 1 i64
+; RUN: %t/input-gen.module.run.a.out %t/input-gen.module.generate.a.out.input.i64.0.bin i64
+; RUN: llvm-profdata merge default.profraw -o %t/default.profdata
+; RUN: mkdir -p %t.withpgo
+; RUN: input-gen --verify --output-dir %t.withpgo --compile-input-gen-executables --input-gen-runtime %S/../../../../input-gen-runtimes/rt-input-gen.cpp --input-run-runtime %S/../../../../input-gen-runtimes/rt-run.cpp --pgo-instr-use %t/default.profdata %s
+
+define dso_local i64 @i64(ptr noundef %LL) local_unnamed_addr #0 {
+entry:
+  %a = load i64, ptr %LL
+  store i64 %a, ptr %LL
+  ret i64 %a
+}


### PR DESCRIPTION
This patch adds flags (and a test) so that the main input-gen binary can add instrumentation to modules and also compile the run modules with a PGO profile. This enables downstream uses of PGO, such as block coverage analysis. Passing the flags directly into the input-gen binary for recompiling with a PGO profile probably isn't what will be used for large scale testing (instead just opting to recompile the bitcode), but probably won't hurt to support.

This is also currently not selective in terms of what gets instrumented. This means that parts of the runtime will end up in the profile. This shouldn't be an issue, but something that we may want to work on in the future.