### PR TITLE
Find possible callee candidates for function pointers and select among those.

### DIFF
--- a/input-gen-runtimes/rt-input-gen.cpp
+++ b/input-gen-runtimes/rt-input-gen.cpp
@@ -726,7 +726,14 @@ struct InputGenRTTy {
                           (void *)Global, Obj.Idx, (void *)ReplGlobal));
   }
 
+  intptr_t registerFunctionPtrIdx(size_t N) {
+    auto Offset = rand(false) % N;
+    FunctionPtrs.push_back(Offset);
+    return Offset;
+  }
+
   std::vector<size_t> Globals;
+  std::vector<intptr_t> FunctionPtrs;
 
   uint64_t NumNewValues = 0;
 
@@ -847,6 +854,12 @@ struct InputGenRTTy {
       InputOut.write(ccast(GenVal.Content), MaxPrimitiveTypeSize);
       writeV<int32_t>(InputOut, GenVal.IsPtr);
     }
+
+    uint32_t NumGenFunctionPtrs = FunctionPtrs.size();
+    writeV<uint32_t>(InputOut, NumGenFunctionPtrs);
+    for(intptr_t FPOffset : FunctionPtrs) {
+      writeV<intptr_t>(InputOut, FPOffset);
+    }
   }
 };
 
@@ -889,6 +902,10 @@ void __inputgen_deinit() {
 void __inputgen_global(int32_t NumGlobals, VoidPtrTy Global,
                        VoidPtrTy *ReplGlobal, int32_t GlobalSize) {
   getInputGenRT().registerGlobal(Global, ReplGlobal, GlobalSize);
+}
+
+VoidPtrTy __inputgen_select_fp(VoidPtrTy *PotentialFPs, uint64_t N) {
+  return PotentialFPs[getInputGenRT().registerFunctionPtrIdx(N)];
 }
 
 // TODO: need to support overlapping Tgt and Src here

--- a/input-gen-runtimes/rt.hpp
+++ b/input-gen-runtimes/rt.hpp
@@ -24,6 +24,7 @@ static constexpr intptr_t ObjAlignment = 16;
 static constexpr intptr_t MaxPrimitiveTypeSize = 16;
 
 typedef uint8_t *VoidPtrTy;
+struct FunctionPtrTy{};
 
 template <typename T> static char *ccast(T *Ptr) {
   return reinterpret_cast<char *>(Ptr);

--- a/input-gen-runtimes/rt.hpp
+++ b/input-gen-runtimes/rt.hpp
@@ -24,7 +24,8 @@ static constexpr intptr_t ObjAlignment = 16;
 static constexpr intptr_t MaxPrimitiveTypeSize = 16;
 
 typedef uint8_t *VoidPtrTy;
-struct FunctionPtrTy{};
+typedef struct {}* FunctionPtrTy;
+
 
 template <typename T> static char *ccast(T *Ptr) {
   return reinterpret_cast<char *>(Ptr);

--- a/llvm/include/llvm/Transforms/IPO/InputGenerationImpl.h
+++ b/llvm/include/llvm/Transforms/IPO/InputGenerationImpl.h
@@ -82,7 +82,7 @@ public:
                        IGInstrumentationModeTy Mode,
                        bool InstrumentedForCoverage)
       : Mode(Mode), MAM(MAM), M(M),
-        InstrumentedForCoverage(InstrumentedForCoverage), StubNameCounter(0) {
+        InstrumentedForCoverage(InstrumentedForCoverage) {
     Ctx = &(M.getContext());
     PtrTy = PointerType::getUnqual(*Ctx);
     Int1Ty = IntegerType::getIntNTy(*Ctx, 1);
@@ -137,7 +137,7 @@ public:
   void createRunEntryPoint(Function &F, bool UniqName);
   void createGlobalCalls(Module &M, IRBuilder<> &IRB);
   void stubDeclaration(Module &M, Function &F);
-  Function &stubDeclaration(Module &M, FunctionType &FT, StringRef Suffix);
+  Function &createFunctionPtrStub(Module &M, FunctionType &FT);
   void stubDeclarations(Module &M, TargetLibraryInfo &TLI);
   void gatherFunctionPtrCallees(Module &M);
   void instrumentFunctionPtrSources(Module &M);
@@ -178,7 +178,8 @@ private:
   FunctionCallee UnreachableCallback;
 
   bool InstrumentedForCoverage;
-  int StubNameCounter;
+  unsigned StubNameCounter = 0;
+  unsigned FpMapNameCounter = 0;
 };
 
 class ModuleInputGenInstrumenter {

--- a/llvm/include/llvm/Transforms/IPO/InputGenerationImpl.h
+++ b/llvm/include/llvm/Transforms/IPO/InputGenerationImpl.h
@@ -82,7 +82,8 @@ public:
                        IGInstrumentationModeTy Mode,
                        bool InstrumentedForCoverage)
       : Mode(Mode), MAM(MAM), M(M),
-        InstrumentedForCoverage(InstrumentedForCoverage) {
+        InstrumentedForCoverage(InstrumentedForCoverage),
+        StubNameCounter(0) {
     Ctx = &(M.getContext());
     PtrTy = PointerType::getUnqual(*Ctx);
     Int1Ty = IntegerType::getIntNTy(*Ctx, 1);
@@ -129,13 +130,14 @@ public:
                                      CallbackCollectionTy &CC, Type *T,
                                      Value *ValueToReplace,
                                      ValueToValueMapTy *VMap);
-  Value *constructFpFromPotentialCallees(const CallBase &Caller, Value& V, IRBuilderBase& IRB);
+  Value *constructFpFromPotentialCallees(const CallBase &Caller, Value &V,
+                                         IRBuilderBase &IRB);
   void createRecordingEntryPoint(Function &F);
   void createGenerationEntryPoint(Function &F, bool UniqName);
   void createRunEntryPoint(Function &F, bool UniqName);
   void createGlobalCalls(Module &M, IRBuilder<> &IRB);
   void stubDeclaration(Module &M, Function &F);
-  Function& stubDeclaration(Module &M, FunctionType& FT, StringRef Suffix);
+  Function &stubDeclaration(Module &M, FunctionType &FT, StringRef Suffix);
   void stubDeclarations(Module &M, TargetLibraryInfo &TLI);
   void gatherFunctionPtrCallees(Module &M);
   void instrumentFunctionPtrSources(Module &M);
@@ -175,6 +177,7 @@ private:
   FunctionCallee UnreachableCallback;
 
   bool InstrumentedForCoverage;
+  int StubNameCounter;
 };
 
 class ModuleInputGenInstrumenter {

--- a/llvm/include/llvm/Transforms/IPO/InputGenerationImpl.h
+++ b/llvm/include/llvm/Transforms/IPO/InputGenerationImpl.h
@@ -129,7 +129,7 @@ public:
                                      CallbackCollectionTy &CC, Type *T,
                                      Value *ValueToReplace,
                                      ValueToValueMapTy *VMap);
-  Value *constructFpFromPotentialCallees(IRBuilderBase &IRB, Argument& Arg);
+  Value *constructFpFromPotentialCallees(const CallBase &Caller, Value& V, IRBuilderBase& IRB);
   void createRecordingEntryPoint(Function &F);
   void createGenerationEntryPoint(Function &F, bool UniqName);
   void createRunEntryPoint(Function &F, bool UniqName);
@@ -138,6 +138,7 @@ public:
   Function& stubDeclaration(Module &M, FunctionType& FT, StringRef Suffix);
   void stubDeclarations(Module &M, TargetLibraryInfo &TLI);
   void gatherFunctionPtrCallees(Module &M);
+  void instrumentFunctionPtrSources(Module &M);
   void provideGlobals(Module &M);
   SetVector<Function *> pruneModule(Function &F);
 
@@ -193,6 +194,7 @@ public:
   bool instrumentEntryPoint(Module &, Function &, bool);
   bool instrumentModuleForFunction(Module &, Function &);
   std::unique_ptr<Module> generateEntryPointModule(Module &M, Function &);
+  bool instrumentFunctionPtrs(Module &);
 
 private:
   Triple TargetTriple;

--- a/llvm/include/llvm/Transforms/IPO/InputGenerationImpl.h
+++ b/llvm/include/llvm/Transforms/IPO/InputGenerationImpl.h
@@ -82,8 +82,7 @@ public:
                        IGInstrumentationModeTy Mode,
                        bool InstrumentedForCoverage)
       : Mode(Mode), MAM(MAM), M(M),
-        InstrumentedForCoverage(InstrumentedForCoverage),
-        StubNameCounter(0) {
+        InstrumentedForCoverage(InstrumentedForCoverage), StubNameCounter(0) {
     Ctx = &(M.getContext());
     PtrTy = PointerType::getUnqual(*Ctx);
     Int1Ty = IntegerType::getIntNTy(*Ctx, 1);
@@ -131,7 +130,8 @@ public:
                                      Value *ValueToReplace,
                                      ValueToValueMapTy *VMap);
   Value *constructFpFromPotentialCallees(const CallBase &Caller, Value &V,
-                                         IRBuilderBase &IRB, SetVector<Instruction*>& ToDelete);
+                                         IRBuilderBase &IRB,
+                                         SetVector<Instruction *> &ToDelete);
   void createRecordingEntryPoint(Function &F);
   void createGenerationEntryPoint(Function &F, bool UniqName);
   void createRunEntryPoint(Function &F, bool UniqName);
@@ -141,6 +141,7 @@ public:
   void stubDeclarations(Module &M, TargetLibraryInfo &TLI);
   void gatherFunctionPtrCallees(Module &M);
   void instrumentFunctionPtrSources(Module &M);
+  void provideFunctionPtrGlobals(Module &M);
   void provideGlobals(Module &M);
   SetVector<Function *> pruneModule(Function &F);
 

--- a/llvm/include/llvm/Transforms/IPO/InputGenerationImpl.h
+++ b/llvm/include/llvm/Transforms/IPO/InputGenerationImpl.h
@@ -129,11 +129,15 @@ public:
                                      CallbackCollectionTy &CC, Type *T,
                                      Value *ValueToReplace,
                                      ValueToValueMapTy *VMap);
+  Value *constructFpFromPotentialCallees(IRBuilderBase &IRB, Argument& Arg);
   void createRecordingEntryPoint(Function &F);
   void createGenerationEntryPoint(Function &F, bool UniqName);
   void createRunEntryPoint(Function &F, bool UniqName);
   void createGlobalCalls(Module &M, IRBuilder<> &IRB);
+  void stubDeclaration(Module &M, Function &F);
+  Function& stubDeclaration(Module &M, FunctionType& FT, StringRef Suffix);
   void stubDeclarations(Module &M, TargetLibraryInfo &TLI);
+  void gatherFunctionPtrCallees(Module &M);
   void provideGlobals(Module &M);
   SetVector<Function *> pruneModule(Function &F);
 

--- a/llvm/include/llvm/Transforms/IPO/InputGenerationImpl.h
+++ b/llvm/include/llvm/Transforms/IPO/InputGenerationImpl.h
@@ -131,7 +131,7 @@ public:
                                      Value *ValueToReplace,
                                      ValueToValueMapTy *VMap);
   Value *constructFpFromPotentialCallees(const CallBase &Caller, Value &V,
-                                         IRBuilderBase &IRB);
+                                         IRBuilderBase &IRB, SetVector<Instruction*>& ToDelete);
   void createRecordingEntryPoint(Function &F);
   void createGenerationEntryPoint(Function &F, bool UniqName);
   void createRunEntryPoint(Function &F, bool UniqName);

--- a/llvm/lib/IR/MDBuilder.cpp
+++ b/llvm/lib/IR/MDBuilder.cpp
@@ -76,9 +76,8 @@ MDNode *MDBuilder::createFunctionEntryCount(
 }
 
 MDNode *MDBuilder::createFunctionSectionPrefix(StringRef Prefix) {
-  return MDNode::get(Context,
-                     {createString("function_section_prefix"),
-                      createString(Prefix)});
+  return MDNode::get(
+      Context, {createString("function_section_prefix"), createString(Prefix)});
 }
 
 MDNode *MDBuilder::createRange(const APInt &Lo, const APInt &Hi) {
@@ -138,9 +137,10 @@ MDNode *MDBuilder::mergeCallbackEncodings(MDNode *ExistingCallbacks,
   for (unsigned u = 0; u < NumExistingOps; u++) {
     Ops[u] = ExistingCallbacks->getOperand(u);
 
-    auto *OldCBCalleeIdxAsCM = cast<ConstantAsMetadata>(Ops[u]);
+    auto *OldCBCalleeIdxAsCM =
+        cast<ConstantAsMetadata>(cast<MDNode>(Ops[u])->getOperand(0));
     uint64_t OldCBCalleeIdx =
-      cast<ConstantInt>(OldCBCalleeIdxAsCM->getValue())->getZExtValue();
+        cast<ConstantInt>(OldCBCalleeIdxAsCM->getValue())->getZExtValue();
     (void)OldCBCalleeIdx;
     assert(NewCBCalleeIdx != OldCBCalleeIdx &&
            "Cannot map a callback callee index twice!");
@@ -329,8 +329,8 @@ MDNode *MDBuilder::createMutableTBAAAccessTag(MDNode *Tag) {
 
 MDNode *MDBuilder::createIrrLoopHeaderWeight(uint64_t Weight) {
   Metadata *Vals[] = {
-    createString("loop_header_weight"),
-    createConstant(ConstantInt::get(Type::getInt64Ty(Context), Weight)),
+      createString("loop_header_weight"),
+      createConstant(ConstantInt::get(Type::getInt64Ty(Context), Weight)),
   };
   return MDNode::get(Context, Vals);
 }

--- a/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
+++ b/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
@@ -6969,7 +6969,7 @@ ChangeStatus AAHeapToStackFunction::updateImpl(Attributor &A) {
         LLVM_DEBUG(
             dbgs()
             << "[H2S] unique free call might not be executed with the allocation "
-            << *UniqueFree << "\n");
+                          << *UniqueFree << "\n");
         return false;
       }
     }
@@ -12335,7 +12335,9 @@ struct AAIndirectCallInfoCallSite : public AAIndirectCallInfo {
     }
 
     // Special handling for the single callee case.
-    if (AllCalleesKnown && AssumedCallees.size() == 1) {
+    if (AllCalleesKnown && AssumedCallees.size() == 1 &&
+        A.shouldSpecializeCallSiteForCallee(*this, *CB,
+                                            *AssumedCallees.back())) {
       auto *NewCallee = AssumedCallees.front();
       if (isLegalToPromote(*CB, NewCallee)) {
         promoteCall(*CB, NewCallee, nullptr);

--- a/llvm/lib/Transforms/IPO/InputGeneration.cpp
+++ b/llvm/lib/Transforms/IPO/InputGeneration.cpp
@@ -1702,10 +1702,10 @@ void InputGenInstrumenter::createGenerationEntryPoint(Function &F,
 
   SmallVector<Value *> Args;
   ValueToValueMapTy VMap;
-  for (uint64_t A = 0; A < F.arg_size(); ++A) {
-    auto &Arg = *F.getArg(A);
+  for (auto &Arg : F.args()) {
     Args.push_back(constructTypeUsingCallbacks(M, IRB, ArgGenCallback,
                                                Arg.getType(), &Arg, &VMap));
+    VMap[&Arg] = Args.back();
   }
   auto *Ret = IRB.CreateCall(FunctionCallee(F.getFunctionType(), &F), Args, "");
   if (Ret->getType()->isVoidTy())

--- a/llvm/lib/Transforms/IPO/InputGeneration.cpp
+++ b/llvm/lib/Transforms/IPO/InputGeneration.cpp
@@ -891,10 +891,12 @@ void InputGenInstrumenter::gatherFunctionPtrCallees(Module &M) {
   for (Function &F : M)
     Functions.insert(&F);
 
+  DenseSet<const char *> Allowed({&AAIndirectCallInfo::ID});
+
   AttributorConfig AC(CGUpdater);
   AC.IsModulePass = true;
   AC.DeleteFns = false;
-  AC.Allowed = nullptr;
+  AC.Allowed = &Allowed;
   AC.UseLiveness = false;
   AC.DefaultInitializeLiveInternals = false;
   AC.IsClosedWorldModule = true;
@@ -1006,10 +1008,32 @@ void InputGenInstrumenter::instrumentFunctionPtrSources(Module &M) {
   for (Function &F : M)
     Functions.insert(&F);
 
+  DenseSet<const char *> Allowed({
+      &AAPotentialValues::ID,
+      &AACallEdges::ID,
+      &AAGlobalValueInfo::ID,
+      &AAIndirectCallInfo::ID,
+      &AAInstanceInfo::ID,
+      &AAInterFnReachability::ID,
+      &AAIntraFnReachability::ID,
+      // &AAIsDead::ID, // this kills insts that are still referred to by the getAssumedSimplifiedValues lookup..
+      &AAMemoryBehavior::ID,
+      &AAMemoryLocation::ID,
+      &AANoCapture::ID,
+      &AANonNull::ID,
+      &AANoRecurse::ID,
+      &AANoReturn::ID,
+      &AANoSync::ID,
+      &AAPointerInfo::ID,
+      &AAPotentialConstantValues::ID,
+      &AAUnderlyingObjects::ID,
+      &AAValueConstantRange::ID,
+  });
+
   AttributorConfig AC(CGUpdater);
   AC.IsModulePass = true;
   AC.DeleteFns = false;
-  AC.Allowed = nullptr;
+  AC.Allowed = &Allowed;
   AC.UseLiveness = false;
   AC.DefaultInitializeLiveInternals = false;
   AC.IsClosedWorldModule = true;

--- a/llvm/test/tools/input-gen/callgraph.ll
+++ b/llvm/test/tools/input-gen/callgraph.ll
@@ -147,17 +147,11 @@ define internal void @usedByGlobal() {
 @G = global ptr @usedByGlobal
 
 define void @broker(ptr %unknown) !callback !0 {
-; OWRDL-LABEL: @broker(
-;
-; CWRLD-LABEL: @broker(
-;
   call void %unknown()
   ret void
 }
 
 define void @func6() {
-; CHECK-LABEL: @func6(
-;
   call void @broker(ptr @func3)
   ret void
 }
@@ -173,6 +167,16 @@ define void @func7(ptr %unknown) {
   ret void
 }
 
+define void @func8(ptr %another_unknown) {
+  call void @broker(ptr %another_unknown)
+  ret void
+}
+
+define void @func9(ptr %mem) {
+  %1 = load ptr, ptr %mem
+  call void @broker(ptr %1)
+  ret void
+}
 
 ;define void @as_cast(ptr %arg) {
 ;; OWRDL-LABEL: @as_cast(

--- a/llvm/test/tools/input-gen/callgraph.ll
+++ b/llvm/test/tools/input-gen/callgraph.ll
@@ -1,0 +1,189 @@
+; RUN: mkdir -p %t
+; RUN: input-gen -g --verify --output-dir %t --compile-input-gen-executables --input-gen-runtime %S/../../../../input-gen-runtimes/rt-input-gen.cpp --input-run-runtime %S/../../../../input-gen-runtimes/rt-run.cpp %s
+; RUN: %S/run_all.sh %t
+
+
+define dso_local void @func1() {
+; CHECK-LABEL: @func1(
+;
+  %1 = icmp ne i32 0, 0
+  br i1 %1, label %2, label %3
+
+2:                                                ; preds = %0
+  call void @func2(i1 false)
+  br label %3
+
+3:                                                ; preds = %2, %0
+  call void () @func3()
+  ret void
+}
+
+declare void @func3()
+define internal void @func4() {
+; CHECK-LABEL: @func4(
+;
+  call void @func3()
+  ret void
+}
+define internal void @internal_good() {
+; CHECK-LABEL: @internal_good(
+;
+  call void @void(ptr @func4)
+  ret void
+}
+
+define dso_local void @func2(i1 %c) {
+; UPTO2-LABEL: @func2(
+;
+; LIMI0-LABEL: @func2(
+;
+  %f = select i1 %c, ptr @internal_good, ptr @func4
+  call void %f()
+  ret void
+}
+
+
+define void @func5(i32 %0) {
+; UPTO2-LABEL: @func5(
+;
+; LIMI0-LABEL: @func5(
+;
+  %2 = icmp ne i32 %0, 0
+  %3 = select i1 %2, ptr @func4, ptr @func3
+  call void () %3()
+  ret void
+}
+
+define i32 @musttailCall(i32 %0) {
+; CHECK-LABEL: @musttailCall(
+;
+  %2 = icmp ne i32 %0, 0
+  %3 = select i1 %2, ptr @func4, ptr @func3
+  %c = musttail call i32 (i32) %3(i32 0)
+  ret i32 %c
+}
+
+declare i32 @retI32()
+declare void @takeI32(i32)
+declare float @retFloatTakeFloat(float)
+; This callee is always filtered out because of the noundef argument
+declare float @retFloatTakeFloatFloatNoundef(float, float noundef)
+declare void @void()
+
+define i32 @non_matching_fp1(i1 %c1, i1 %c2, i1 %c) {
+; UNLIM-LABEL: @non_matching_fp1(
+;
+; LIMI2-LABEL: @non_matching_fp1(
+;
+; LIMI0-LABEL: @non_matching_fp1(
+;
+  %fp1 = select i1 %c1, ptr @retI32, ptr @takeI32
+  %fp2 = select i1 %c2, ptr @retFloatTakeFloat, ptr @void
+  %fp = select i1 %c, ptr %fp1, ptr %fp2
+  %call = call i32 %fp(i32 42)
+  ret i32 %call
+}
+
+define i32 @non_matching_fp1_noundef(i1 %c1, i1 %c2, i1 %c) {
+; UNLIM-LABEL: @non_matching_fp1_noundef(
+;
+; LIMI2-LABEL: @non_matching_fp1_noundef(
+;
+; LIMI0-LABEL: @non_matching_fp1_noundef(
+;
+  %fp1 = select i1 %c1, ptr @retI32, ptr @takeI32
+  %fp2 = select i1 %c2, ptr @retFloatTakeFloatFloatNoundef, ptr @void
+  %fp = select i1 %c, ptr %fp1, ptr %fp2
+  %call = call i32 %fp(i32 42)
+  ret i32 %call
+}
+
+define void @non_matching_fp2(i1 %c1, i1 %c2, i1 %c, ptr %unknown) {
+; OUNLM-LABEL: @non_matching_fp2(
+;
+; LIMI2-LABEL: @non_matching_fp2(
+;
+; LIMI0-LABEL: @non_matching_fp2(
+;
+; CWRLD-LABEL: @non_matching_fp2(
+;
+  %fp1 = select i1 %c1, ptr @retI32, ptr @takeI32
+  %fp2 = select i1 %c2, ptr @retFloatTakeFloat, ptr %unknown
+  %fp = select i1 %c, ptr %fp1, ptr %fp2
+  call void %fp()
+  ret void
+}
+
+define i32 @non_matching_unknown(i1 %c, ptr %fn) {
+; OUNLM-LABEL: @non_matching_unknown(
+;
+; LIMI2-LABEL: @non_matching_unknown(
+;
+; LIMI0-LABEL: @non_matching_unknown(
+;
+; CWRLD-LABEL: @non_matching_unknown(
+;
+  %fp = select i1 %c, ptr @retI32, ptr %fn
+  %call = call i32 %fp(i32 42)
+  ret i32 %call
+}
+
+; This function is used in a "direct" call but with a different signature.
+; We check that it does not show up above in any of the if-cascades because
+; the address is not actually taken.
+declare void @usedOnlyInCastedDirectCall(i32)
+define void @usedOnlyInCastedDirectCallCaller() {
+; CHECK-LABEL: @usedOnlyInCastedDirectCallCaller(
+;
+  call void @usedOnlyInCastedDirectCall()
+  ret void
+}
+
+define internal void @usedByGlobal() {
+; CHECK-LABEL: @usedByGlobal(
+;
+  ret void
+}
+@G = global ptr @usedByGlobal
+
+define void @broker(ptr %unknown) !callback !0 {
+; OWRDL-LABEL: @broker(
+;
+; CWRLD-LABEL: @broker(
+;
+  call void %unknown()
+  ret void
+}
+
+define void @func6() {
+; CHECK-LABEL: @func6(
+;
+  call void @broker(ptr @func3)
+  ret void
+}
+
+; Cannot be internal_good as it is internal and we see all uses.
+; Can be func4 since it escapes.
+define void @func7(ptr %unknown) {
+; UPTO2-LABEL: @func7(
+;
+; LIMI0-LABEL: @func7(
+;
+  call void %unknown(), !callees !2
+  ret void
+}
+
+
+;define void @as_cast(ptr %arg) {
+;; OWRDL-LABEL: @as_cast(
+;;
+;; CWRLD-LABEL: @as_cast(
+;;
+;  %fp = load ptr, ptr %arg, align 8
+;  tail call void %fp()
+;  ret void
+;}
+
+!0 = !{!1}
+!1 = !{i64 0, i1 false}
+!2 = !{ptr @func3, ptr @func4}

--- a/llvm/test/tools/input-gen/masked_rw.ll
+++ b/llvm/test/tools/input-gen/masked_rw.ll
@@ -18,7 +18,7 @@ declare void @llvm.masked.store.v4i32.p0(<4 x i32>, ptr nocapture, i32 immarg, <
 declare <4 x i32> @llvm.masked.load.v4i32.p0(ptr nocapture, i32 immarg, <4 x i1>, <4 x i32>)
 
 
-; LOAD-LABEL: define dso_local <4 x i32> @__inputgen_renamed_load(
+; LOAD-LABEL: define private <4 x i32> @__inputgen_renamed_load(
 ; LOAD-SAME: ptr nocapture noundef readonly [[P:%.*]], <4 x i1> [[MASK:%.*]], <4 x i32> [[PT:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {
 ; LOAD-NEXT:  entry:
 ; LOAD-NEXT:    [[TMP0:%.*]] = extractelement <4 x i1> [[MASK]], i64 0
@@ -52,7 +52,7 @@ declare <4 x i32> @llvm.masked.load.v4i32.p0(ptr nocapture, i32 immarg, <4 x i1>
 ; LOAD:       15:
 ; LOAD-NEXT:    ret <4 x i32> [[A]]
 ;
-; STORE-LABEL: define dso_local void @__inputgen_renamed_store(
+; STORE-LABEL: define private void @__inputgen_renamed_store(
 ; STORE-SAME: ptr nocapture noundef writeonly [[P:%.*]], <4 x i1> [[MASK:%.*]], <4 x i32> [[PT:%.*]]) local_unnamed_addr #[[ATTR1:[0-9]+]] {
 ; STORE-NEXT:  entry:
 ; STORE-NEXT:    [[TMP0:%.*]] = extractelement <4 x i1> [[MASK]], i64 0

--- a/llvm/tools/input-gen/input-gen.cpp
+++ b/llvm/tools/input-gen/input-gen.cpp
@@ -300,6 +300,7 @@ public:
         continue;
       }
     }
+    MIGI.instrumentFunctionPtrs(*InstrM);
 
     postprocessModule(*InstrM, Mode);
 

--- a/scripts/input_gen_module.py
+++ b/scripts/input_gen_module.py
@@ -25,6 +25,7 @@ def add_option_args(parser):
     parser.add_argument('--coverage-statistics', action='store_true')
     parser.add_argument('--coverage-runtime')
     parser.add_argument('--branch-hints', action='store_true')
+    parser.add_argument('--disable-fp-handling', action='store_true')
 
 class Function:
     def __init__(self, name, ident, verbose, generate_profs):
@@ -245,6 +246,8 @@ class InputGenModule:
             if profdata_filename:
                 self.ig_instrument_args.append('--profile-path')
                 self.ig_instrument_args.append(profdata_filename)
+            if self.disable_fp_handling:
+                self.ig_instrument_args.append("--input-gen-instrument-function-ptrs=false")
 
             self.print("input-gen args:", " ".join(self.ig_instrument_args))
             subprocess.run(self.ig_instrument_args,

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,2 @@
+datasets
+jug


### PR DESCRIPTION
This (currently) has a few restrictions:
- Attributor has to find possible callees in the first place.
- Only function pointers being handed directly to the function under investigation are handled (e.g. `as_cast` is therefore unsupported atm)

So we will want to steer away from direct arg handling (and likely/maybe also from callback metadata) and use AAPotentialValues to identify which source values to instrument.

So far I haven't been able to do a full test run, as I'm still waiting for bank access on a suitable machine.